### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just grab two files `GDWebViewController.swift` and `GDWebViewNavigationToolbar.
 You can download `GDWebBrowserClient` project as well to see how it can be used.
 
 ## GDWebViewController Interface
-####Properties
+#### Properties
 ```swift
 weak var delegate: GDWebViewControllerDelegate?
 ```
@@ -55,7 +55,7 @@ var allowJavaScriptAlerts: Bool
 ```
 Boolean flag which indicates whether JavaScript alerts are allowed. Default is `true`.
     
-####Methods
+#### Methods
 ```swift
 func loadURLWithString(_ URLString: String)
 ```
@@ -76,7 +76,7 @@ func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((AnyObje
 ```
 Evaluates the given JavaScript string.
 
-####GDWebViewControllerDelegate Methods
+#### GDWebViewControllerDelegate Methods
 ```swift
 @objc public protocol GDWebViewControllerDelegate {
     @objc optional func webViewController(_ webViewController: GDWebViewController, didChangeURL newURL: URL?)
@@ -92,7 +92,7 @@ Notice:<br />
 You must do `import WebKit` if you use last three methods from `GDWebViewControllerDelegate` description.
 
 ## GDWebViewNavigationToolbar Interface
-####Properties
+#### Properties
 ```swift
 var toolbarTintColor: UIColor?
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
